### PR TITLE
Feat: 모먼트, 흔적, 알림, 리액션 Entity 및 Enum 타입 정의

### DIFF
--- a/src/main/java/com/RollinMoment/RollinMomentServer/alert/entity/Alert.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/alert/entity/Alert.java
@@ -1,0 +1,115 @@
+package com.RollinMoment.RollinMomentServer.alert.entity;
+
+import com.RollinMoment.RollinMomentServer.common.type.AlertStatus;
+import com.RollinMoment.RollinMomentServer.common.type.AlertType;
+import com.RollinMoment.RollinMomentServer.common.type.LocationType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+//@Entity
+@Table(name = "alert")
+@Getter
+@NoArgsConstructor
+public class Alert {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "alert_code", nullable = false)
+	private String alertCode;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "alert_type", nullable = false, columnDefinition = "ENUM('NOTICE','MOMENT','TRACE','REACTION','PROMOTION')")
+	private AlertType alertType;
+
+	@Column(name = "user_id", nullable = false)
+	private String userId;
+
+	@Column(name = "title")
+	private String title;
+
+	@Column(name = "content")
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "location_type", nullable = false, columnDefinition = "ENUM('IN_APP','OUTSIDE')")
+	private LocationType locationType;
+
+	@Column(name = "data_key")
+	private String dataKey;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, columnDefinition = "ENUM('WAITING','SENT','SEND_FAILED','READ')")
+	private AlertStatus status = AlertStatus.WAITING;
+
+	@Column(name = "outer_url")
+	private String outerUrl;
+
+	@CreatedDate
+	@Column(name = "send_at", nullable = false)
+	private LocalDateTime sendAt;
+
+	public Alert(AlertType alertType, String userId, String title, String content, LocationType locationType, String dataKey, String outerUrl) {
+		this.alertType = alertType;
+		this.userId = userId;
+		this.title = title;
+		this.content = content;
+		this.locationType = locationType;
+		this.dataKey = dataKey;
+		this.outerUrl = outerUrl;
+		this.alertCode = generateAlertCode(alertType, userId);
+	}
+
+	public static Alert notice(String userId, String title, String content, LocationType locationType, String dataKey, String outerUrl) {
+		return new Alert(AlertType.NOTICE, userId, title, content, locationType, dataKey, outerUrl);
+	}
+
+	public static Alert moment(String userId, String title, String content, LocationType locationType, String dataKey, String outerUrl) {
+		return new Alert(AlertType.MOMENT, userId, title, content, locationType, dataKey, outerUrl);
+	}
+
+	public static Alert trace(String userId, String title, String content, LocationType locationType, String dataKey, String outerUrl) {
+		return new Alert(AlertType.TRACE, userId, title, content, locationType, dataKey, outerUrl);
+	}
+
+	public static Alert reaction(String userId, String title, String content, LocationType locationType, String dataKey, String outerUrl) {
+		return new Alert(AlertType.REACTION, userId, title, content, locationType, dataKey, outerUrl);
+	}
+
+	public static Alert promotion(String userId, String title, String content, LocationType locationType, String dataKey, String outerUrl) {
+		return new Alert(AlertType.PROMOTION, userId, title, content, locationType, dataKey, outerUrl);
+	}
+
+	private String generateAlertCode(AlertType type, String userId) {
+		// TODO :: alert_code 형식 정의 필요
+		//      type_timemillis_randomtext? ex.리액션 -> R{user_id}{currentTimeMillis} ??
+		return String.format("%s%s%s", type.getCode(), userId, System.currentTimeMillis());
+	}
+
+	public void sentSuccess() {
+		if(this.status == AlertStatus.WAITING) {
+			this.status = AlertStatus.SENT;
+		} else {
+			throw new IllegalArgumentException("전송 대기 상태인 알림만 전송할 수 있습니다.");
+		}
+	}
+
+	public void sentFailed() {
+		if(this.status == AlertStatus.WAITING) {
+			this.status = AlertStatus.SEND_FAILED;
+		} else {
+			throw new IllegalArgumentException("전송 대기 상태인 알림만 전송할 수 있습니다.");
+		}
+	}
+
+	public void read() {
+		if(this.status == AlertStatus.SENT) {
+			this.status = AlertStatus.READ;
+		} else {
+			throw new IllegalArgumentException("전송되지 않은 알림은 읽음 처리 할 수 없습니다.");
+		}
+	}
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/GenerateUtils.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/GenerateUtils.java
@@ -1,0 +1,28 @@
+package com.RollinMoment.RollinMomentServer.common;
+
+import com.RollinMoment.RollinMomentServer.common.type.PageType;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class GenerateUtils {
+
+	public static String makeMomentCode() {
+		return makeCode(PageType.MOMENT);
+	}
+
+	public static String makeTraceCode() {
+		return makeCode(PageType.TRACE);
+	}
+
+	// TODO : pk 형식 정해서 generate 현재(임시) :: MO2025031719557974290
+	private static String makeCode(PageType type) {
+		return type.getCodePrefix()
+					   + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyDD"))
+					   + System.currentTimeMillis();
+	}
+
+	public static String makeInviteCode(String momentCode) {
+		return momentCode + "_invite";
+	}
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/GenerateUtils.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/GenerateUtils.java
@@ -15,6 +15,10 @@ public class GenerateUtils {
 		return makeCode(PageType.TRACE);
 	}
 
+	public static String makeReactionCode() {
+		return makeCode(PageType.REACTION);
+	}
+
 	// TODO : pk 형식 정해서 generate 현재(임시) :: MO2025031719557974290
 	private static String makeCode(PageType type) {
 		return type.getCodePrefix()

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/type/AlertStatus.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/type/AlertStatus.java
@@ -1,0 +1,14 @@
+package com.RollinMoment.RollinMomentServer.common.type;
+
+public enum AlertStatus {
+	WAITING("전송 대기"),
+	SENT("전송 완료"),
+	SEND_FAILED("전송 실패"),
+	READ("읽음");
+
+	private String krName;
+
+	AlertStatus(String krName) {
+		this.krName = krName;
+	}
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/type/AlertType.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/type/AlertType.java
@@ -1,0 +1,24 @@
+package com.RollinMoment.RollinMomentServer.common.type;
+
+import lombok.Getter;
+
+@Getter
+public enum AlertType {
+	NOTICE("공지사항", "notice", "N"),                // 관리자가 발송한 알림. (공지)
+	MOMENT("모먼트", "moment", "M"),
+	REACTION("리액션", "moment", "R"),
+	TRACE("흔적", "moment", "T"),
+	PROMOTION("이벤트/혜택", "promotion", "P");
+
+	// 2025.03.26 mvp 개발 -> 모먼트/리액션/흔적 모두 모먼트 페이지로 이동 / 추후 화면 변동이 있다면 각각 다른 페이지로 안내 필요
+
+	private String krName;
+	private String location;
+	private String code;
+
+	AlertType(String krName, String location, String code) {
+		this.krName = krName;
+		this.location = location;
+		this.code = code;
+	}
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/type/BgColor.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/type/BgColor.java
@@ -1,0 +1,28 @@
+package com.RollinMoment.RollinMomentServer.common.type;
+
+public enum BgColor {
+	RED("빨강", "#FBD4D4", 0),
+	ORANGE("주황", "#FFEBC6", 1),
+	YELLOW("노랑", "#FEF8CC", 2),
+	BLUE("파랑", "#DDEFFB", 3),
+	GREEN("초록", "#D9F5ED", 4),
+	MINT("민트", "#E6F5E7", 5),
+	PINK("핑크", "#FFE4FA", 6),
+	PURPLE("보라", "#E3E1FF", 7),
+	NAVY("남색", "#D8E2F3", 8),
+	GRAY("회색", "#F6F6F6", 9);
+
+	private String krName;
+	private String colorCode;
+	private Integer index;
+
+	BgColor(String krName, String colorCode, Integer index) {
+		this.krName = krName;
+		this.colorCode = colorCode;
+		this.index = index;
+	}
+
+	public String code() {
+		return this.colorCode;
+	}
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/type/Category.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/type/Category.java
@@ -1,0 +1,26 @@
+package com.RollinMoment.RollinMomentServer.common.type;
+
+public enum Category {
+	WEDDING("결혼", ""), // 결혼
+	BIRTHDAY("생일", ""), // 생일
+	FIRST_BIRTHDAY("돌잔치", ""), // 돌잔치
+	GRADUATION("졸업", ""), // 졸업
+	FAREWELL("송별회", ""), // 송별회
+	CHRISTMAS("크리스마스", ""), // 크리스마스
+	TEACHERS_DAY("스승의 날", ""), // 스승의 날
+	APPRECIATION("감사", ""), // 감사
+	CHEERING("응원", ""), // 응원
+	CONFESSION("고백", ""), // 고백
+	PRAISE("칭찬", ""), // 칭찬
+	CELEBRATION("축하", ""); // 축하
+
+	// TODO:: 첫 순간을 모아놓은 카테고리가 있으면 어떨까? (ex. 돌잔치 -> First Birthday / 첫 연주회 등..?
+
+	private String krName;
+	private String description;
+
+	Category(String krName, String description) {
+		this.krName = krName;
+		this.description = description;
+	}
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/type/CoverImgType.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/type/CoverImgType.java
@@ -1,0 +1,14 @@
+package com.RollinMoment.RollinMomentServer.common.type;
+
+public enum CoverImgType {
+	CUSTOM("카메라 또는 앨범"),
+	ANNIVERSARY("기념의 순간"),
+	SENDING_HEARTS("마음 전하기"),
+	FAREWELL("작별의 순간");
+
+	private String krName;
+
+	CoverImgType(String krName) {
+		this.krName = krName;
+	}
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/type/EntityType.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/type/EntityType.java
@@ -1,0 +1,7 @@
+package com.RollinMoment.RollinMomentServer.common.type;
+
+public enum EntityType {
+	MOMENT,
+	TRACE,
+	O
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/type/Font.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/type/Font.java
@@ -1,0 +1,7 @@
+package com.RollinMoment.RollinMomentServer.common.type;
+
+public enum Font {
+	DEFAULT,
+	BOLD,
+	ITALIC
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/type/LocationType.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/type/LocationType.java
@@ -1,0 +1,13 @@
+package com.RollinMoment.RollinMomentServer.common.type;
+
+public enum LocationType {
+	IN_APP("인앱 이동"),
+	OUTSIDE("외부 이동");
+
+	private String krName;
+
+	LocationType(String krName) {
+		this.krName = krName;
+	}
+}
+

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/type/PageType.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/type/PageType.java
@@ -1,0 +1,21 @@
+package com.RollinMoment.RollinMomentServer.common.type;
+
+import lombok.Getter;
+
+@Getter
+public enum PageType {
+	MOMENT("moment", "모먼트", "MO"),
+	TRACE("trace", "흔적", "TR"),
+	NOTICE("notice", "공지사항", "NO"),
+	PROMOTION("promotion", "이벤트/혜택", "PRO");
+
+	private String enName;
+	private String krName;
+	private String codePrefix;
+
+	PageType(String enName, String krName, String codePrefix) {
+		this.enName = enName;
+		this.krName = krName;
+		this.codePrefix = codePrefix;
+	}
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/type/PageType.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/type/PageType.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public enum PageType {
 	MOMENT("moment", "모먼트", "MO"),
+	REACTION("reaction", "리액션", "RE"),
 	TRACE("trace", "흔적", "TR"),
 	NOTICE("notice", "공지사항", "NO"),
 	PROMOTION("promotion", "이벤트/혜택", "PRO");

--- a/src/main/java/com/RollinMoment/RollinMomentServer/common/type/PeriodType.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/common/type/PeriodType.java
@@ -1,0 +1,18 @@
+package com.RollinMoment.RollinMomentServer.common.type;
+
+import lombok.Getter;
+
+@Getter
+public enum PeriodType {
+	NONE("없음", 0),
+	THREE_DAYS_LATER("3일 후", 3),
+	SEVEN_DAYS_LATER("7일 후", 7);
+
+	private String krName;
+	private Integer days;
+
+	PeriodType(String krName, Integer days) {
+		this.krName = krName;
+		this.days = days;
+	}
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/moment/entity/Moment.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/moment/entity/Moment.java
@@ -1,0 +1,106 @@
+package com.RollinMoment.RollinMomentServer.moment.entity;
+
+import com.RollinMoment.RollinMomentServer.common.GenerateUtils;
+import com.RollinMoment.RollinMomentServer.common.type.BgColor;
+import com.RollinMoment.RollinMomentServer.common.type.PeriodType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "moment")
+@Getter
+@NoArgsConstructor
+public class Moment {
+	@Id
+	private String code;
+
+	@Column(name = "invite_code", nullable = false)
+	private String inviteCode;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "bgColor", nullable = false,
+			columnDefinition = "ENUM('RED','ORANGE','YELLOW','BLUE','GREEN','MINT','PINK','PURPLE','NAVY','GRAY')")
+	@Enumerated(EnumType.STRING)
+	private BgColor bgColor;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@Column(name = "moment_cover_img_code")
+	private MomentCoverImg coverImg;
+
+	@Column(name = "font", nullable = false)
+	private String font;				// font 미설정 시 default
+
+	@Column(name = "expire_type", nullable = false,
+	 		columnDefinition = "ENUM('NONE','THREE_DAYS_LATER','SEVEN_DAYS_LATER')")
+	@Enumerated(EnumType.STRING)
+	private PeriodType expireType;
+
+	@Column(name = "expire_at")
+	private LocalDateTime expireAt;		// expireType == None 인 경우 null
+
+	@Column(name = "category_en_name", nullable = false)
+	private String categoryEnName;
+
+	@Column(name = "comment")
+	private String comment;
+
+	@Column(name = "receiver")
+	private String receiver; // 수신자 user_id - nullable?
+
+	@Column(name = "is_public", nullable = false)
+	private Boolean isPublic;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "is_deleted", nullable = false)
+	private Boolean isDeleted;
+
+	public Moment(String title, MomentCoverImg coverImg, String font, PeriodType expireType, String categoryEnName,
+				  String comment, String receiver, Boolean isPublic) {
+		this.code = GenerateUtils.makeMomentCode();
+		this.inviteCode = GenerateUtils.makeInviteCode(this.code);
+		this.title = title;
+		this.bgColor = randomBgColor();
+		this.coverImg = coverImg;
+		this.font = font;
+		this.expireType = expireType;
+		this.expireAt = makeExpireDate(expireType);
+		this.categoryEnName = categoryEnName;
+		this.comment = comment;
+		this.receiver = receiver;
+		this.isPublic = isPublic;
+	}
+
+	public void updateMomentInfo() {
+		// TODO : moment patch (설정 수정)
+	}
+
+	public void deleteMoment() {
+		// TODO : softDelete -- 어디까지 지울 것인가?
+	}
+
+	public void sendMomentTo(String userId) {
+		// TODO : 모먼트 선물하기 -> mvp 이후 , 후순위 (useId 에게 모든 권한 이양?)
+		//		선물한 이력이 남는지? 등등 재확인 필요
+	}
+
+
+	// TODO : 배경 컬러 랜덤으로 설정 -> BgColor 에 index 설정 후 math.random 활용
+	private BgColor randomBgColor() {
+		int random = (int) ((Math.random()*10) % 10);
+		System.out.println(BgColor.class.getSuperclass().getDeclaredFields());
+		return null;
+	}
+
+	private LocalDateTime makeExpireDate(PeriodType expireType) {
+		return LocalDateTime.now().plusDays(expireType.getDays());
+	}
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/moment/entity/MomentCategory.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/moment/entity/MomentCategory.java
@@ -1,0 +1,34 @@
+package com.RollinMoment.RollinMomentServer.moment.entity;
+
+import com.RollinMoment.RollinMomentServer.common.type.Category;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "moment")
+@Getter
+@NoArgsConstructor
+public class MomentCategory {
+	@Id
+	@Enumerated(EnumType.STRING)
+	@Column(name = "en_name",
+			columnDefinition = "ENUM('WEDDING','BIRTHDAY','FIRST_BIRTHDAY','GRADUATION','FAREWELL','CHRISTMAS'," +
+									   "'TEACHERS_DAY','APPRECIATION','CHEERING','CONFESSION','PRAISE','CELEBRATION')")
+	private Category category;
+
+	@Column(name = "is_public", nullable = false)
+	private Boolean isPublic;
+
+	@CreatedDate
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
+
+	@CreatedBy
+	@Column(name = "created_by")
+	private String createdBy;		// 추후 관리자 명
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/moment/entity/MomentCoverImg.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/moment/entity/MomentCoverImg.java
@@ -1,0 +1,29 @@
+package com.RollinMoment.RollinMomentServer.moment.entity;
+
+import com.RollinMoment.RollinMomentServer.common.type.CoverImgType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "moment_cover_img")
+@Getter
+@NoArgsConstructor
+public class MomentCoverImg {
+	@Id
+	@Column(name = "code")
+	private String code;
+
+	@Column(name = "type", nullable = false,
+			columnDefinition = "ENUM('ANNIVERSARY','SENDING_HEARS','FAREWELL')")
+	private CoverImgType type;
+
+	@Column(name = "url", nullable = false)
+	private String url;
+
+	@Column(name = "file_name", nullable = false)
+	private String fileName;
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/reaction/entity/Reaction.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/reaction/entity/Reaction.java
@@ -1,0 +1,45 @@
+package com.RollinMoment.RollinMomentServer.reaction.entity;
+
+import com.RollinMoment.RollinMomentServer.common.GenerateUtils;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "moment")
+@Getter
+@NoArgsConstructor
+public class Reaction {
+	@Id
+	@Column(name = "code")
+	private String code;
+
+	@Column(name = "type", nullable = false)
+	private String typeName;
+
+	@Column(name = "trace_code")
+	private String traceCode;
+
+	@Column(name = "reacted_user")
+	private String reactedUser;
+
+	@Column(name = "created_at")
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	public Reaction(String typeName, String traceCode, String reactedUser) {
+		this.code = GenerateUtils.makeReactionCode();
+		this.typeName = typeName;
+		this.traceCode = traceCode;
+		this.reactedUser = reactedUser;
+	}
+
+	public static Reaction heart(String traceCode, String user) {
+		// TODO : 리액션하기 메소드 구현 시 참고
+		return new Reaction("HEART", traceCode, user);
+	}
+
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/reaction/entity/ReactionType.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/reaction/entity/ReactionType.java
@@ -1,0 +1,40 @@
+package com.RollinMoment.RollinMomentServer.reaction.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reaction_type")
+@Getter
+@NoArgsConstructor
+public class ReactionType {
+	@Id
+	@Column(name = "type_name")
+	private String typeName;
+
+	@Column(name = "kr_name")
+	private String krName;
+
+	@Column(name = "description")
+	private String description;
+
+	@Column(name = "icon")
+	private String icon;
+
+	@Column(name = "created_at")
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@Column(name = "is_public")
+	private Boolean isPublic;
+
+	@Column(name = "created_by")
+	@CreatedBy
+	private String createdBy;
+
+}

--- a/src/main/java/com/RollinMoment/RollinMomentServer/trace/entity/Trace.java
+++ b/src/main/java/com/RollinMoment/RollinMomentServer/trace/entity/Trace.java
@@ -1,0 +1,61 @@
+package com.RollinMoment.RollinMomentServer.trace.entity;
+
+import com.RollinMoment.RollinMomentServer.common.GenerateUtils;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "trace")
+@Getter
+@NoArgsConstructor
+public class Trace {
+	@Id
+	@Column(name = "code")
+	private String code;
+
+	@Column(name = "moment_code", nullable = false)
+	private String momentCode;
+
+	@Column(name = "writer", nullable = false)
+	private String writer;		// 작성자 userId
+
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	@Column(name = "is_anonymous", nullable = false)
+	private Boolean isAnonymous;
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@Column(name = "is_removed", nullable = false)
+	private Boolean isRemoved;
+
+	@Column(name = "removed_at")
+	private LocalDateTime removedAt;
+
+	public Trace(String momentCode, String writer, String content, Boolean isAnonymous,
+				 LocalDateTime removedAt) {
+		this.code = GenerateUtils.makeTraceCode();
+		this.momentCode = momentCode;
+		this.writer = writer;
+		this.content = content;
+		this.isAnonymous = isAnonymous;
+		this.isRemoved = false;
+		this.removedAt = removedAt;
+	}
+
+	public void remove(String writer) {
+		if(!this.writer.equals(writer)) {
+			throw new IllegalArgumentException("작성자만 흔적을 지울 수 있습니다.");
+		}
+		this.isRemoved = true;
+	}
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 모먼트 , 흔적, 알림, 리액션 Entity 및 필요 Enum 타입을 정의했습니다.
-  notion에 작성된 DB 테이블을 참고하였습니다.

  <br/>

## 🔧 앞으로의 과제

- 일요일 온라인 회의 전까지, 모먼트 생성 / 수정 API 구현 예정입니다.
- 추후 빠른 시일 내에 4가지 엔티티에 관련된 API를 구현하도록 하겠습니다.

